### PR TITLE
No more empty hidden field on chooser widget

### DIFF
--- a/lib/model/doctrine/PluginsfImagePoolImageTable.class.php
+++ b/lib/model/doctrine/PluginsfImagePoolImageTable.class.php
@@ -82,6 +82,7 @@ class PluginsfImagePoolImageTable extends Doctrine_Table
    */
   public function getByIds($image_ids)
   {
+    if(empty($image_ids)) return new Doctrine_Collection('sfImagePoolImage');
     return $this->getByIdsQuery($image_ids)->execute();
   }
   

--- a/lib/template/sfImagePoolable.class.php
+++ b/lib/template/sfImagePoolable.class.php
@@ -316,7 +316,13 @@ class sfImagePoolable extends Doctrine_Template
    */
   public function setSfImagePoolIds($values)
   {
+    if(!is_array($values))
+    {
+      $values = array();
+    }
+
     // Fix for empty image ids
+    //  - BL: May not be necessary since 9df5ac46b6d811c544d19d9760a071feea8c9dfa
     foreach ($values as $idx => $image_id) 
     { 
       if (empty($image_id)) unset($values[$idx]); 

--- a/modules/sfImagePoolAdmin/templates/_widget.php
+++ b/modules/sfImagePoolAdmin/templates/_widget.php
@@ -1,14 +1,14 @@
 <?php use_helper('ImagePool'); ?>
 
-<div id="<?php echo $id; ?>" class="imageChooser<?php if ($multiple) echo ' multiple'; ?>">
+<div id="<?php echo $id; ?>" class="imageChooser<?php if ($multiple) echo ' multiple'; ?>"
+  data-chooser-name="<?php echo $name ?>"
+  >
   <div class="selectedImage">
     <?php foreach ($images as $i): ?>
       <?php echo pool_image_tag($i, '100', 'crop', array('id'=>'sf_image_pool_image_'+$i->getPrimaryKey())); ?>
       <input type="hidden" name="<?php echo $name; ?>[]" value="<?php echo $i->getPrimaryKey(); ?>" />
     <?php endforeach; ?>
   </div>
-  
-  <input type="hidden" name="<?php echo $name; ?>[]" value="" class="sf-image-id" />
   
   <div class="thumbnailsContainer">
     <?php include_partial('sfImagePoolAdmin/chooser_pagination', array(

--- a/web/js/sfImageChooser.js
+++ b/web/js/sfImageChooser.js
@@ -7,15 +7,15 @@ var ImageChooser = new Class(
   
   options: 
   {
-    toggleClass:        'toggleThumbnails',
-    containerClass:     'thumbnailsContainer',
-    paginationClass:    'pagination',
-    selectedImageClass: 'selectedImage',
-    selectedImageInputClass: 'sf-image-id',
-    uploadImageClass:   'upload_new_image',
-    uploadBackClass:    'image_upload_back',
-    imageOnClickEvent:  null, // for custom behaviour on image click
-    onSuccessEvent:     null  // any additional events that should be called on success (function)
+    toggleClass:              'toggleThumbnails',
+    containerClass:           'thumbnailsContainer',
+    paginationClass:          'pagination',
+    selectedImageClass:       'selectedImage',
+    selectedImageInputClass:  'sf-image-id',
+    uploadImageClass:         'upload_new_image',
+    uploadBackClass:          'image_upload_back',
+    imageOnClickEvent:        null, // for custom behaviour on image click
+    onSuccessEvent:           null  // any additional events that should be called on success (function)
   },
   
   imageChooser:         null,
@@ -37,7 +37,6 @@ var ImageChooser = new Class(
     this.multiple             = this.imageChooser.hasClass('multiple');
     
     this.selectedImage        = this.imageChooser.getElement('.'+this.options.selectedImageClass);
-    this.selectedImageInput   = this.imageChooser.getElement('.'+this.options.selectedImageInputClass);
     this.thumbnailsContainer  = this.imageChooser.getElement('.'+this.options.containerClass);
     this.toggle               = this.imageChooser.getElement('.'+this.options.toggleClass);
     
@@ -155,7 +154,7 @@ var ImageChooser = new Class(
     {
       'type':         'hidden',
       'value':        selectedId,
-      'name':         self.selectedImageInput.get('name')
+      'name':         self.imageChooser.get('data-chooser-name') + '[]'
     });
     
     if (!self.multiple)


### PR DESCRIPTION
As per commit message, fairly trivial commit to do away with the empty input that's present (and unused) every time the widget is rendered, it was causing problems for me when un-assigning an image and not replacing it.
